### PR TITLE
perf/result-comparator

### DIFF
--- a/lib/file-client/result-templates.ts
+++ b/lib/file-client/result-templates.ts
@@ -14,6 +14,7 @@ export interface Result {
     extension?: string;
     source: LintMessage['source'];
     error?: LintMessage['error'];
+    __internalHash: string & { readonly _: unique symbol };
 }
 
 export interface ComparisonResults {

--- a/lib/file-client/results-writer.ts
+++ b/lib/file-client/results-writer.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { isMainThread } from 'worker_threads';
+import objectHash from 'object-hash';
 
 import ResultsStore from './results-store';
 import {
@@ -46,7 +47,7 @@ function parseMessages(messages: LintMessage[]): Result[] {
         const filePath = pathParts.join('/') + lines;
         const postfix = filePath ? `/blob/HEAD/${filePath}` : '';
 
-        return {
+        const resultWithoutHash: Omit<Result, '__internalHash'> = {
             repository,
             repositoryOwner,
             rule: result.ruleId,
@@ -56,6 +57,13 @@ function parseMessages(messages: LintMessage[]): Result[] {
             extension,
             source: result.source,
             error: result.error,
+        };
+
+        return {
+            ...resultWithoutHash,
+            __internalHash: objectHash(
+                resultWithoutHash
+            ) as Result['__internalHash'],
         };
     });
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,7 +91,7 @@ async function scanRepo(repository: string) {
                 // Simply call postMessage({ type: 'DEBUG', payload: ... }) on
                 // worker thread and place breakpoint here
                 case 'DEBUG':
-                    return;
+                    return logger.onDebug(message.payload);
             }
         },
         // On scan timeout terminate all on-going workers

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -112,7 +112,7 @@ async function scanRepo(repository: string) {
     try {
         writeResults(results, repository);
     } catch (e) {
-        logger.onWriteFailure(repository);
+        logger.onWriteFailure(repository, e);
     }
 
     logger.onLintEnd(repository, results.length);

--- a/lib/progress-logger/log-templates.ts
+++ b/lib/progress-logger/log-templates.ts
@@ -99,8 +99,8 @@ export const CLONE_FAILURE_TEMPLATE = (repository: string): string =>
 export const READ_FAILURE_TEMPLATE = (repository: string): string =>
     `[ERROR] ${repository} failed to read files`;
 
-export const WRITE_FAILURE_TEMPLATE = (repository: string): string =>
-    `[ERROR] ${repository} failed to write results`;
+export const WRITE_FAILURE_TEMPLATE = (repository: string, e: Error): string =>
+    `[ERROR] ${repository} failed to write results: ${e.message}`;
 
 export const OVERFLOWING_ROWS_TOP = (overflowingRowCount: number): string =>
     `[\u25B2 to see ${overflowingRowCount} lines above]`;

--- a/lib/progress-logger/log-templates.ts
+++ b/lib/progress-logger/log-templates.ts
@@ -118,3 +118,6 @@ export const SCAN_TIMELIMIT_REACHED = (timeSeconds: number): string =>
 
 export const SCAN_FINISHED = (scannedRepositories: number): string =>
     `[DONE] Finished scan of ${scannedRepositories} repositories`;
+
+export const DEBUG_TEMPLATE = (message: string): string =>
+    `[DEBUG ${new Date().toTimeString().split(' ')[0]}] ${message}`;

--- a/lib/progress-logger/progress-logger.ts
+++ b/lib/progress-logger/progress-logger.ts
@@ -431,6 +431,17 @@ class ProgressLogger {
         this.hasTimedout = true;
         this.listeners.timeout.forEach(listener => listener());
     }
+
+    /**
+     * Log debug message
+     */
+    onDebug(...messages: any[]) {
+        this.addNewMessage({
+            content: Templates.DEBUG_TEMPLATE(messages.join('\n')),
+            color: 'yellow',
+            level: 'verbose',
+        });
+    }
 }
 
 export default new ProgressLogger();

--- a/lib/progress-logger/progress-logger.ts
+++ b/lib/progress-logger/progress-logger.ts
@@ -375,9 +375,9 @@ class ProgressLogger {
     /**
      * Log error about result writing failure
      */
-    onWriteFailure(repository: string) {
+    onWriteFailure(repository: string, error: Error) {
         this.addNewMessage({
-            content: Templates.WRITE_FAILURE_TEMPLATE(repository),
+            content: Templates.WRITE_FAILURE_TEMPLATE(repository, error),
             color: 'red',
             level: 'error',
         });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "homepage": "https://github.com/AriPerkkio/eslint-remote-tester",
     "bugs": "https://github.com/AriPerkkio/eslint-remote-tester",
     "dependencies": {
-        "@babel/code-frame": "^7.12.11",
+        "@babel/code-frame": "^7.12.13",
         "chalk": "^4.1.0",
         "ink": "^3.0.8",
         "object-hash": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@babel/code-frame": "^7.12.11",
         "chalk": "^4.1.0",
         "ink": "^3.0.8",
+        "object-hash": "^2.1.1",
         "react": "^16.14.0",
         "simple-git": "^2.20.1"
     },
@@ -46,6 +47,7 @@
         "@types/eslint": "^7.2.2",
         "@types/jest": "^26.0.15",
         "@types/node": "^14.10.1",
+        "@types/object-hash": "^1.3.4",
         "@types/react": "^16.9.53",
         "@typescript-eslint/eslint-plugin": "^4.1.0",
         "@typescript-eslint/parser": "^4.1.0",

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -115,7 +115,7 @@ describe('integration', () => {
             \`\`\`js
               1 | // Identifier.name = attributeForCrashing
             > 2 | window.attributeForCrashing();
-              3 | 
+              3 |
             \`\`\`
 
             \`\`\`
@@ -142,7 +142,7 @@ describe('integration', () => {
             \`\`\`js
             > 1 | var foo = bar;
                 |           ^^^
-              2 | 
+              2 |
               3 | if (foo) {
               4 | }
             \`\`\`
@@ -155,12 +155,12 @@ describe('integration', () => {
 
             \`\`\`js
               1 | var foo = bar;
-              2 | 
+              2 |
             > 3 | if (foo) {
                 |          ^
             > 4 | }
                 | ^^
-              5 | 
+              5 |
               6 | var p = {
               7 |     get name(){
             \`\`\`
@@ -172,7 +172,7 @@ describe('integration', () => {
             -   [Link](https://github.com/AriPerkkio/eslint-remote-tester-integration-test-target/blob/HEAD/index.js#L7-L7)
 
             \`\`\`js
-               5 | 
+               5 |
                6 | var p = {
             >  7 |     get name(){
                  |     ^^^^^^^^
@@ -188,8 +188,8 @@ describe('integration', () => {
             -   [Link](https://github.com/AriPerkkio/eslint-remote-tester-integration-test-target/blob/HEAD/index.js#L14-L14)
 
             \`\`\`js
-              12 | 
-              13 | 
+              12 |
+              13 |
             > 14 | if (foo === -0) {
                  |     ^^^^^^^^^^
               15 |   // prevent no-empty
@@ -368,7 +368,7 @@ describe('integration', () => {
             [SOURCE]
               1 | // Identifier.name = attributeForCrashing
             > 2 | window.attributeForCrashing();
-              3 | 
+              3 |
             [SOURCE]
             .
             [ERROR]
@@ -417,7 +417,7 @@ describe('integration', () => {
             [SOURCE]
             > 1 | var foo = bar;
                 |           ^^^
-              2 | 
+              2 |
               3 | if (foo) {
               4 | }
             [SOURCE]
@@ -456,12 +456,12 @@ describe('integration', () => {
             .
             [SOURCE]
               1 | var foo = bar;
-              2 | 
+              2 |
             > 3 | if (foo) {
                 |          ^
             > 4 | }
                 | ^^
-              5 | 
+              5 |
               6 | var p = {
               7 |     get name(){
             [SOURCE]
@@ -499,7 +499,7 @@ describe('integration', () => {
             [EXTENSION]
             .
             [SOURCE]
-               5 | 
+               5 |
                6 | var p = {
             >  7 |     get name(){
                  |     ^^^^^^^^
@@ -541,8 +541,8 @@ describe('integration', () => {
             [EXTENSION]
             .
             [SOURCE]
-              12 | 
-              13 | 
+              12 |
+              13 |
             > 14 | if (foo === -0) {
                  |     ^^^^^^^^^^
               15 |   // prevent no-empty
@@ -642,7 +642,7 @@ describe('integration', () => {
               1 | // Identifier.name = attributeForCrashing
             > 2 | window.attributeForCrashing();
                 | ^^^^^^
-              3 | 
+              3 |
             \`\`\`
 
             ## Rule: no-undef
@@ -654,7 +654,7 @@ describe('integration', () => {
             \`\`\`js
             > 1 | var foo = bar;
                 |           ^^^
-              2 | 
+              2 |
               3 | if (foo) {
               4 | }
             \`\`\`
@@ -669,8 +669,8 @@ describe('integration', () => {
             -   [Link](https://github.com/AriPerkkio/eslint-remote-tester-integration-test-target/blob/HEAD/index.js#L14-L14)
 
             \`\`\`js
-              12 | 
-              13 | 
+              12 |
+              13 |
             > 14 | if (foo === -0) {
                  |     ^^^^^^^^^^
               15 |   // prevent no-empty
@@ -889,7 +889,7 @@ describe('integration', () => {
               1 | // Identifier.name = attributeForCrashing
             > 2 | window.attributeForCrashing();
                 | ^^^^^^
-              3 | 
+              3 |
             [SOURCE]
             .
             [ERROR]
@@ -927,7 +927,7 @@ describe('integration', () => {
             [SOURCE]
             > 1 | var foo = bar;
                 |           ^^^
-              2 | 
+              2 |
               3 | if (foo) {
               4 | }
             [SOURCE]
@@ -967,8 +967,8 @@ describe('integration', () => {
             [EXTENSION]
             .
             [SOURCE]
-              12 | 
-              13 | 
+              12 |
+              13 |
             > 14 | if (foo === -0) {
                  |     ^^^^^^^^^^
               15 |   // prevent no-empty

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -313,6 +313,7 @@ describe('integration', () => {
 
                 results.forEach(result => {
                     Object.entries(result).forEach(([key, value]) => {
+                        if (key === '__internalHash') return;
                         const block = `[${key.toUpperCase()}]`;
 
                         console.log('.');
@@ -830,6 +831,7 @@ describe('integration', () => {
                     // @ts-ignore
                     comparisonResults[type].forEach(result => {
                         Object.entries(result).forEach(([key, value]) => {
+                            if (key === '__internalHash') return;
                             const block = `[${key.toUpperCase()}]`;
 
                             console.log('.');

--- a/test/unit/file-client.test.ts
+++ b/test/unit/file-client.test.ts
@@ -74,6 +74,7 @@ function generateResult(prefix = '0'): Result {
         extension: `${prefix}-extension`,
         source: `${prefix}-source`,
         error: `${prefix}-error`,
+        __internalHash: `${prefix}-__internalHash` as Result['__internalHash'],
     };
 }
 
@@ -161,49 +162,15 @@ describe('file-client', () => {
             expect(results.added).toHaveLength(0);
         });
 
-        test('identifies changes in result.link', () => {
+        test('identifies changes in result.__internalHash', () => {
             const result = generateResult();
-            createComparisonCache({ ...result, link: '1' });
+            createComparisonCache({ ...result, __internalHash: '1' as any });
 
-            const results = compareResults([{ ...result, link: '2' }]);
+            const results = compareResults([
+                { ...result, __internalHash: '2' as any },
+            ]);
 
-            expect(results.added).toEqual([{ ...result, link: '2' }]);
-        });
-
-        test('identifies changes in result.rule', () => {
-            const result = generateResult();
-            createComparisonCache({ ...result, rule: '1' });
-
-            const results = compareResults([{ ...result, rule: '2' }]);
-
-            expect(results.added).toEqual([{ ...result, rule: '2' }]);
-        });
-
-        test('identifies changes in result.message', () => {
-            const result = generateResult();
-            createComparisonCache({ ...result, message: '1' });
-
-            const results = compareResults([{ ...result, message: '2' }]);
-
-            expect(results.added).toEqual([{ ...result, message: '2' }]);
-        });
-
-        test('identifies changes in result.source', () => {
-            const result = generateResult();
-            createComparisonCache({ ...result, source: '1' });
-
-            const results = compareResults([{ ...result, source: '2' }]);
-
-            expect(results.added).toEqual([{ ...result, source: '2' }]);
-        });
-
-        test('identifies changes in result.error', () => {
-            const result = generateResult();
-            createComparisonCache({ ...result, error: '1' });
-
-            const results = compareResults([{ ...result, error: '2' }]);
-
-            expect(results.added).toEqual([{ ...result, error: '2' }]);
+            expect(results.added).toEqual([{ ...result, __internalHash: '2' }]);
         });
 
         test('marks all results as "added" when previous results are not found', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,6 +815,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/object-hash@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.4.tgz#079ba142be65833293673254831b5e3e847fe58b"
+  integrity sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -4280,6 +4285,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
+  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
 object-inspect@^1.8.0:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   dependencies:
-    "@babel/highlight" "^7.10.4"
+    "@babel/highlight" "^7.12.13"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.12.3"
@@ -133,6 +133,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
 "@babel/helpers@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.1.tgz#8a8261c1d438ec18cb890434df4ec768734c1e79"
@@ -148,6 +153,15 @@
   integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
+  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 


### PR DESCRIPTION
```
perf(result-comparator): add internal hash for comparing results via map
    
- Comparing arrays is extremely slow with larger data sets
- Adds internal object hash for Results. Used when comparing results.
- Improves compareResults() execution from 20mins to 2s when comparings 500Mb JSON
```