### PR TITLE
feat: move cache under `node_modules`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,10 +68,11 @@ module.exports = {
             },
         },
         {
-            files: ['*.test.ts*'],
+            files: ['*.test.ts*', '**/__mocks__/*'],
             rules: {
                 '@typescript-eslint/no-non-null-assertion': 'off',
                 '@typescript-eslint/ban-ts-comment': 'off',
+                '@typescript-eslint/explicit-module-boundary-types': 'off',
             },
         },
     ],

--- a/lib/file-client/file-constants.ts
+++ b/lib/file-client/file-constants.ts
@@ -1,5 +1,27 @@
+import fs from 'fs';
+
+const ROOT = '.';
+const CACHE_DIR = '/.cache-eslint-remote-tester';
+const NODE_MODULES = '/node_modules';
+const ESLINT_REMOTE_TESTER = '/eslint-remote-tester';
+
+function initializeCacheDirectory() {
+    if (fs.existsSync(ROOT + NODE_MODULES + ESLINT_REMOTE_TESTER)) {
+        // Has eslint-remote-tester installed under node_modules
+        return ROOT + NODE_MODULES + ESLINT_REMOTE_TESTER + CACHE_DIR;
+    }
+
+    if (fs.existsSync(ROOT + NODE_MODULES)) {
+        // Has node_modules but no eslint-remote-tester installed locally
+        return ROOT + NODE_MODULES + CACHE_DIR;
+    }
+
+    // Has no node_modules
+    return ROOT + CACHE_DIR;
+}
+
 /** Directory where repositories are cloned to */
-export const CACHE_LOCATION = './.cache-eslint-remote-tester';
+export const CACHE_LOCATION = initializeCacheDirectory();
 
 /** Directory where results are generated in to */
 export const RESULTS_LOCATION = './eslint-remote-tester-results';

--- a/lib/file-client/index.ts
+++ b/lib/file-client/index.ts
@@ -16,6 +16,6 @@ export {
     RESULTS_COMPARE_LOCATION,
     RESULTS_COMPARISON_CACHE_LOCATION,
 } from './file-constants';
-export { removeCachedRepository } from './repository-client';
+export { getCacheStatus, removeCachedRepository } from './repository-client';
 export { default as ResultsStore } from './results-store';
 export { RESULTS_TEMPLATE_CI_BASE } from './result-templates';

--- a/lib/file-client/repository-client.ts
+++ b/lib/file-client/repository-client.ts
@@ -72,3 +72,36 @@ export async function removeCachedRepository(
         fs.rmdirSync(repoLocation, { recursive: true });
     }
 }
+
+/**
+ * Get status of cache. Includes count of cached repositories and location of the cache.
+ */
+export function getCacheStatus(): {
+    countOfRepositories: number;
+    location: string;
+} {
+    let countOfRepositories = 0;
+
+    if (fs.existsSync(CACHE_LOCATION)) {
+        // Root level directories are users/organizations, e.g. `@testing-library`
+        const repositoryOwners = fs.readdirSync(CACHE_LOCATION);
+
+        repositoryOwners.forEach(repositoryOwner => {
+            const stats = fs.statSync(`${CACHE_LOCATION}/${repositoryOwner}`);
+
+            // Check type just to be sure
+            if (!stats.isDirectory()) return;
+
+            const repositories = fs.readdirSync(
+                `${CACHE_LOCATION}/${repositoryOwner}`
+            );
+
+            countOfRepositories += repositories.length;
+        });
+    }
+
+    return {
+        countOfRepositories,
+        location: CACHE_LOCATION,
+    };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ import { renderApplication } from '@ui';
 import config, { validateConfig } from '@config';
 import engine from '@engine';
 import { LintMessage } from '@engine/types';
-import { prepareResultsDirectory, writeResults } from '@file-client';
+import * as fileClient from '@file-client';
 import logger from '@progress-logger';
 
 /**
@@ -25,8 +25,10 @@ async function main() {
     }
 
     await validateConfig(config);
-    prepareResultsDirectory();
+    fileClient.prepareResultsDirectory();
+
     renderApplication();
+    logger.onCacheStatus(fileClient.getCacheStatus());
 
     // Start x amount of task runners parallel until we are out of repositories to scan
     await Promise.all(
@@ -36,6 +38,7 @@ async function main() {
     );
 
     logger.onAllRepositoriesScanned();
+    logger.onCacheStatus(fileClient.getCacheStatus());
 }
 
 /**
@@ -120,7 +123,7 @@ async function scanRepo(repository: string) {
     );
 
     try {
-        await writeResults(results, repository);
+        await fileClient.writeResults(results, repository);
     } catch (e) {
         logger.onWriteFailure(repository, e);
     }

--- a/lib/progress-logger/log-templates.ts
+++ b/lib/progress-logger/log-templates.ts
@@ -61,6 +61,11 @@ export const CI_STATUS_TEMPLATE = (
 [INFO/STATUS] Errors (${errorCount})
 ${tasks.map(task => CI_TASK_TEMPLATE(task)).join('\n')}\n`;
 
+export const CACHE_STATUS_TEMPLATE = (
+    repositoriesCount: number,
+    location: string
+): string => `[INFO] Cached repositories (${repositoriesCount}) at ${location}`;
+
 const CI_TASK_TEMPLATE = (task: Task): string =>
     `[INFO]${TASK_TEMPLATE(task)}`.replace(CI_TEMPLATE_TASK_REGEXP, '/');
 

--- a/lib/progress-logger/progress-logger.ts
+++ b/lib/progress-logger/progress-logger.ts
@@ -429,6 +429,28 @@ class ProgressLogger {
     }
 
     /**
+     * Log status of cache. Includes count of cached repositories and location of cache.
+     * Only used in CLI
+     */
+    onCacheStatus(status: { countOfRepositories: number; location: string }) {
+        if (config.CI) return;
+
+        // Prevent logging useless "0 cached repositories" cases
+        if (status.countOfRepositories <= 0) return;
+
+        if (['verbose', 'info'].includes(config.logLevel)) {
+            this.addNewMessage({
+                content: Templates.CACHE_STATUS_TEMPLATE(
+                    status.countOfRepositories,
+                    status.location
+                ),
+                level: 'info',
+                color: 'yellow',
+            });
+        }
+    }
+
+    /**
      * Log notification about reaching scan time limit and notify listeners
      */
     private onScanTimeout() {
@@ -448,7 +470,7 @@ class ProgressLogger {
         this.addNewMessage({
             content: Templates.DEBUG_TEMPLATE(messages.join('\n')),
             color: 'yellow',
-            level: 'verbose',
+            level: 'error', // Always visible
         });
     }
 }

--- a/lib/ui/components/MessagesScrollBox.tsx
+++ b/lib/ui/components/MessagesScrollBox.tsx
@@ -69,11 +69,7 @@ const MessagesScrollBox: React.FC = ({ children }) => {
     }
 
     return (
-        <Box
-            flexDirection='column'
-            marginTop={scannedRepositories > 0 ? 1 : 0}
-            height={areaHeight}
-        >
+        <Box flexDirection='column' marginTop={1} height={areaHeight}>
             {visibleMessages}
         </Box>
     );

--- a/test/integration/integration.action-exports.test.ts
+++ b/test/integration/integration.action-exports.test.ts
@@ -29,7 +29,7 @@ describe('integration - compare action exports', () => {
         expect(
             actionExports.RESULTS_COMPARISON_CACHE_LOCATION
         ).toMatchInlineSnapshot(
-            `"./.cache-eslint-remote-tester/.comparison-cache.json"`
+            `"./node_modules/.cache-eslint-remote-tester/.comparison-cache.json"`
         );
     });
 

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -208,7 +208,7 @@ describe('integration', () => {
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target crashed: unable-to-parse-rule-id
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 5 errors
             [DONE] Finished scan of 1 repositories
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
 
             "
         `);
@@ -248,7 +248,7 @@ describe('integration', () => {
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target crashed: unable-to-parse-rule-id
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 5 errors
             [DONE] Finished scan of 1 repositories
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
 
             "
         `);
@@ -257,11 +257,11 @@ describe('integration', () => {
 
         expect(cachedRun.output.pop()).toMatchInlineSnapshot(`
             "Full log:
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target crashed: unable-to-parse-rule-id
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 5 errors
             [DONE] Finished scan of 1 repositories
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
 
             "
         `);
@@ -1092,7 +1092,7 @@ describe('integration', () => {
              eol-last - AriPerkkio/eslint-remote-tester-integration-test-target
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 21 errors
             [DONE] Finished scan of 1 repositories
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
 
             "
         `);

--- a/test/integration/jest.setup.integration.ts
+++ b/test/integration/jest.setup.integration.ts
@@ -1,10 +1,10 @@
-import { addFailureLogger, clearResultsCache } from '../utils';
+import { addFailureLogger, clearRepositoryCache } from '../utils';
 
 jest.setTimeout(15000);
 addFailureLogger();
 
 beforeEach(async () => {
-    clearResultsCache();
+    clearRepositoryCache();
 
     // Timeout between tests - otherwise constant `git clone` calls start failing
     await new Promise(r => setTimeout(r, 2000));

--- a/test/smoke/jest.setup.smoke.ts
+++ b/test/smoke/jest.setup.smoke.ts
@@ -1,8 +1,8 @@
-import { addFailureLogger, clearResultsCache } from '../utils';
+import { addFailureLogger, clearRepositoryCache } from '../utils';
 
 jest.setTimeout(300000);
 addFailureLogger();
 
 beforeEach(async () => {
-    clearResultsCache();
+    clearRepositoryCache();
 });

--- a/test/smoke/smoke.test.ts
+++ b/test/smoke/smoke.test.ts
@@ -22,12 +22,14 @@ describe('smoke', () => {
         );
 
         expect(output.pop()).toMatchInlineSnapshot(`
-        "Full log:
-        [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 56000 errors
-        [DONE] Finished scan of 1 repositories
-        [DONE] Result comparison: Added 56000. Removed 56000.
+            "Full log:
+            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 56000 errors
+            [DONE] Finished scan of 1 repositories
+            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [DONE] Result comparison: Added 56000. Removed 56000.
 
-        "
-    `);
+            "
+        `);
     });
 });

--- a/test/smoke/smoke.test.ts
+++ b/test/smoke/smoke.test.ts
@@ -23,10 +23,10 @@ describe('smoke', () => {
 
         expect(output.pop()).toMatchInlineSnapshot(`
             "Full log:
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
             [ERROR] AriPerkkio/eslint-remote-tester-integration-test-target 56000 errors
             [DONE] Finished scan of 1 repositories
-            [INFO] Cached repositories (1) at ./.cache-eslint-remote-tester
+            [INFO] Cached repositories (1) at ./node_modules/.cache-eslint-remote-tester
             [DONE] Result comparison: Added 56000. Removed 56000.
 
             "

--- a/test/unit/__mocks__/@file-client.ts
+++ b/test/unit/__mocks__/@file-client.ts
@@ -4,6 +4,10 @@ export const writeResults = jest.fn();
 export const prepareResultsDirectory = jest.fn();
 export const removeCachedRepository = jest.fn();
 export const getFilesMock = jest.fn();
+export const getCacheStatus = () => ({
+    countOfRepositories: 0,
+    location: 'mock-cache',
+});
 
 export const ResultsStore = {
     getResults: jest.fn().mockReturnValue(['MOCK_RESULT']),

--- a/test/unit/__mocks__/@progress-logger.ts
+++ b/test/unit/__mocks__/@progress-logger.ts
@@ -22,6 +22,7 @@ class MockLogger {
     onReadFailure = jest.fn();
     onWriteFailure = jest.fn();
     onLintEnd = jest.fn();
+    onCacheStatus = jest.fn();
 
     on = jest.fn().mockImplementation((event: ListenerType, listener) => {
         const eventListeners = this.mockListeners[event];

--- a/test/unit/__mocks__/simple-git.ts
+++ b/test/unit/__mocks__/simple-git.ts
@@ -1,0 +1,9 @@
+const clone = jest.fn();
+const pull = jest.fn();
+
+export default function SimpleGit(): {
+    clone: typeof clone;
+    pull: typeof pull;
+} {
+    return { clone, pull };
+}

--- a/test/unit/file-client.test.ts
+++ b/test/unit/file-client.test.ts
@@ -7,6 +7,7 @@ import {
     RESULTS_LOCATION,
     RESULTS_COMPARE_DIR,
     RESULTS_COMPARISON_CACHE_LOCATION,
+    CACHE_LOCATION,
 } from '@file-client';
 import {
     Result,
@@ -49,6 +50,10 @@ function createResults(): void {
 
 function createComparisonCache(...results: Result[]): void {
     removeComparisonCache();
+
+    if (!fs.existsSync(CACHE_LOCATION)) {
+        fs.mkdirSync(CACHE_LOCATION);
+    }
 
     fs.writeFileSync(
         RESULTS_COMPARISON_CACHE_LOCATION,

--- a/test/unit/file-client.test.ts
+++ b/test/unit/file-client.test.ts
@@ -97,6 +97,18 @@ function createComparisonResults(): void {
     );
 }
 
+function getCacheLocation() {
+    let location = '';
+
+    jest.resetModuleRegistry();
+    jest.isolateModules(() => {
+        location = require('../../lib/file-client/file-constants')
+            .CACHE_LOCATION;
+    });
+
+    return location;
+}
+
 describe('file-client', () => {
     describe('prepareResultsDirectory', () => {
         afterEach(() => {
@@ -242,6 +254,33 @@ describe('file-client', () => {
             await writeComparisonResults({ added: [], removed: [] }, [
                 generateResult(),
             ]);
+        });
+    });
+
+    describe('CACHE_LOCATION', () => {
+        test('is initialized under package in node_modules', () => {
+            jest.mock('fs', () => ({ existsSync: () => true }));
+
+            expect(getCacheLocation()).toBe(
+                './node_modules/eslint-remote-tester/.cache-eslint-remote-tester'
+            );
+        });
+
+        test('is initialized under node_modules when package is not installed', () => {
+            jest.mock('fs', () => ({
+                existsSync: (path: string) =>
+                    path !== './node_modules/eslint-remote-tester',
+            }));
+
+            expect(getCacheLocation()).toBe(
+                './node_modules/.cache-eslint-remote-tester'
+            );
+        });
+
+        test('is initialized in root when node_modules is not available', () => {
+            jest.mock('fs', () => ({ existsSync: () => false }));
+
+            expect(getCacheLocation()).toBe('./.cache-eslint-remote-tester');
         });
     });
 });

--- a/test/unit/repository-client.test.ts
+++ b/test/unit/repository-client.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@file-client/repository-client';
 import SimpleGit from '__mocks__/simple-git';
 
-const EXPECTED_CACHE = './.cache-eslint-remote-tester';
+const EXPECTED_CACHE = './node_modules/.cache-eslint-remote-tester';
 
 describe('repository-client', () => {
     beforeEach(() => {

--- a/test/unit/repository-client.test.ts
+++ b/test/unit/repository-client.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 
 import {
     cloneRepository,
+    getCacheStatus,
     removeCachedRepository,
 } from '@file-client/repository-client';
 import SimpleGit from '__mocks__/simple-git';
@@ -64,6 +65,27 @@ describe('repository-client', () => {
             expect(fs.existsSync(`${EXPECTED_CACHE}/${repository}`)).toBe(
                 false
             );
+        });
+    });
+
+    describe('getCacheStatus', () => {
+        test('returns count of repositories', () => {
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-1`);
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-1/repository-1`);
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-1/repository-2`);
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-1/repository-3`);
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-1/repository-4`);
+
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-2`);
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-2/repository-1`);
+
+            fs.mkdirSync(`${EXPECTED_CACHE}/user-3`);
+
+            expect(getCacheStatus().countOfRepositories).toBe(5);
+        });
+
+        test('returns location of cache', () => {
+            expect(getCacheStatus().location).toBe(EXPECTED_CACHE);
         });
     });
 });

--- a/test/unit/repository-client.test.ts
+++ b/test/unit/repository-client.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+
+import {
+    cloneRepository,
+    removeCachedRepository,
+} from '@file-client/repository-client';
+import SimpleGit from '__mocks__/simple-git';
+
+const EXPECTED_CACHE = './.cache-eslint-remote-tester';
+
+describe('repository-client', () => {
+    beforeEach(() => {
+        SimpleGit().clone.mockClear();
+        SimpleGit().pull.mockClear();
+
+        // Clear previous cache
+        if (fs.existsSync(EXPECTED_CACHE)) {
+            fs.rmdirSync(EXPECTED_CACHE, { recursive: true });
+        }
+
+        // Initialize client
+        jest.resetModuleRegistry();
+        jest.isolateModules(() => {
+            require('../../lib/file-client/repository-client');
+        });
+    });
+
+    test('creates cache directory', () => {
+        expect(fs.existsSync(EXPECTED_CACHE)).toBe(true);
+        expect(fs.statSync(EXPECTED_CACHE).isDirectory()).toBe(true);
+    });
+
+    describe('cloneRepository', () => {
+        test('clones repositories into cache', async () => {
+            const repository = 'mock-user/mock-repository';
+
+            await cloneRepository({
+                repository,
+                onClone: jest.fn(),
+                onCloneFailure: jest.fn(),
+                onPull: jest.fn(),
+                onPullFailure: jest.fn(),
+            });
+
+            expect(
+                SimpleGit().clone
+            ).toHaveBeenCalledWith(
+                'https://github.com/mock-user/mock-repository.git',
+                `${EXPECTED_CACHE}/${repository}`,
+                { '--depth': 1 }
+            );
+        });
+    });
+
+    describe('removeCachedRepository', () => {
+        test('removes repository from cache', async () => {
+            const repository = 'mock-repository';
+
+            fs.mkdirSync(`${EXPECTED_CACHE}/${repository}`);
+            fs.writeFileSync(`${EXPECTED_CACHE}/${repository}/index.js`, '//');
+
+            await removeCachedRepository(repository);
+
+            expect(fs.existsSync(`${EXPECTED_CACHE}/${repository}`)).toBe(
+                false
+            );
+        });
+    });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -82,7 +82,15 @@ export async function runProductionBuild(
             encoding: 'utf8',
             cols: 999, // Prevent word wrap
             rows: 999, // Prevent ink from erasing the screen,
-            env: { ...process.env, NODE_OPTIONS: '--max_old_space_size=5120' },
+            env: {
+                ...process.env,
+
+                // For smoke test to not crash
+                NODE_OPTIONS: '--max_old_space_size=5120',
+
+                // Force ink to render even when run in CI
+                CI: 'false',
+            },
         });
         const output: string[] = [];
         ptyProcess.onData(data => {
@@ -149,11 +157,11 @@ function parsePtyOutput(output: string[]): string[] {
 }
 
 /**
- * Remove possible result caches
+ * Remove possible repository caches
  */
-export function clearResultsCache(): void {
-    if (fs.existsSync(REPOSITORY_CACHE)) {
-        fs.rmdirSync(REPOSITORY_CACHE, { recursive: true });
+export function clearRepositoryCache(): void {
+    if (fs.existsSync(CACHE_LOCATION)) {
+        fs.rmdirSync(CACHE_LOCATION, { recursive: true });
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/AriPerkkio/eslint-remote-tester/issues/100

Not considered as breaking change since cache location is already private API. 