### PR TITLE
Improved tsconfig: Target the actual feature set of Node >=12

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "devDependencies": {
         "@commitlint/cli": "^12.1.1",
         "@commitlint/config-conventional": "^12.1.1",
+        "@tsconfig/node12": "^1.0.8",
         "@types/babel__code-frame": "^7.0.2",
         "@types/eslint": "^7.2.2",
         "@types/jest": "^26.0.15",

--- a/test/integration/integration.action-exports.test.ts
+++ b/test/integration/integration.action-exports.test.ts
@@ -58,7 +58,7 @@ describe('integration - compare action exports', () => {
             export { RESULT_COMPARISON_CACHE, RESULTS_COMPARISON_CACHE_LOCATION, } from './file-client/file-constants';
             export { default as validateConfig } from './config/validator';
             export { Config, ConfigToValidate } from './config/types';
-            "
+            //# sourceMappingURL=exports-for-compare-action.d.ts.map"
         `);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "jsx": "react",
         "declaration": true,
+        "declarationMap": true,
         "baseUrl": ".",
         "paths": {
             "@config": ["lib/config"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node12/tsconfig.json",
+    "extends": "./node_modules/@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
         "outDir": "dist",
         "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
-        "strict": true,
-        "module": "commonjs",
-        "target": "es6",
         "outDir": "dist",
         "moduleResolution": "node",
-        "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,
         "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tsconfig/node12@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.8.tgz#a883d62f049a64fea1e56a6bbe66828d11c6241b"
+  integrity sha512-LM6XwBhjZRls1qJGpiM/It09SntEwe9M0riXRfQ9s6XlJQG0JPGl92ET18LtGeYh/GuOtafIXqwZeqLOd0FNFQ==
+
 "@types/babel__code-frame@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.2.tgz#e0c0f1648cbc09a9d4e5b4ed2ae9a6f7c8f5aeb0"


### PR DESCRIPTION
`es6` also goes by the name of `es2015` and eg. async/await [didn't arrive until `es2017`](https://stackoverflow.com/a/47995659/20667) while Node 12 actually supports even `es2019` fully.

Rather than keeping track of all of that in here, and ensuring to stay up to date here when new LTS versions gets released, I included [a shared recommended minimal tsconfig](https://github.com/tsconfig/bases) as a base tsconfig for eg. that data.

On top of that I also added [`declarationMap`](https://www.typescriptlang.org/tsconfig#declarationMap) to get source maps which maps from `.d.ts` to the original `.ts` files. This helps in debugging things and looking things up in eg. VSCode.

Sorry for not updating the lock file, my local yarn was acting up (I've moved to npm again myself since a few months so my new computer haven't really had yarn on it)

Also sorry for not using proper styling of the commit messages, maybe you can do a squash merge and/or cherry pick and set the correct commit messages then?