### PR TITLE
Add GH Actions cache for Yarn cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - run: |
                   yarn install
                   yarn build
@@ -35,6 +44,15 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - run: |
                   yarn install
                   yarn build
@@ -51,6 +69,15 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - run: |
                   yarn install
                   yarn build
@@ -69,6 +96,15 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - run: |
                   yarn install
                   yarn build
@@ -87,6 +123,15 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - run: yarn install
               name: Install eslint-remote-tester
             - run: yarn install

--- a/.github/workflows/lint-eslint-config-airbnb.yml
+++ b/.github/workflows/lint-eslint-config-airbnb.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-core-ts.yml
+++ b/.github/workflows/lint-eslint-core-ts.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-core.yml
+++ b/.github/workflows/lint-eslint-core.yml
@@ -25,10 +25,10 @@ jobs:
               run: echo "::set-output name=dir::$(yarn cache dir)"
             - uses: actions/cache@v2
               with:
-                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                restore-keys: |
-                  ${{ runner.os }}-yarn-
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-core.yml
+++ b/.github/workflows/lint-eslint-core.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-cypress.yml
+++ b/.github/workflows/lint-eslint-plugin-cypress.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-import.yml
+++ b/.github/workflows/lint-eslint-plugin-import.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-jest-dom.yml
+++ b/.github/workflows/lint-eslint-plugin-jest-dom.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-jest.yml
+++ b/.github/workflows/lint-eslint-plugin-jest.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-jsx-a11y.yml
+++ b/.github/workflows/lint-eslint-plugin-jsx-a11y.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-mocha.yml
+++ b/.github/workflows/lint-eslint-plugin-mocha.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-node.yml
+++ b/.github/workflows/lint-eslint-plugin-node.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-react-hooks.yml
+++ b/.github/workflows/lint-eslint-plugin-react-hooks.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-react-redux.yml
+++ b/.github/workflows/lint-eslint-plugin-react-redux.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-react.yml
+++ b/.github/workflows/lint-eslint-plugin-react.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-regexp.yml
+++ b/.github/workflows/lint-eslint-plugin-regexp.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-sonarjs.yml
+++ b/.github/workflows/lint-eslint-plugin-sonarjs.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-testing-library.yml
+++ b/.github/workflows/lint-eslint-plugin-testing-library.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-eslint-plugin-unicorn.yml
+++ b/.github/workflows/lint-eslint-plugin-unicorn.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/.github/workflows/lint-typescript-eslint-eslint-plugin.yml
+++ b/.github/workflows/lint-typescript-eslint-eslint-plugin.yml
@@ -20,6 +20,15 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: 14
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install

--- a/ci/generate-workflows.js
+++ b/ci/generate-workflows.js
@@ -2,12 +2,11 @@
  * eslint-configs and eslint-plugins are handled the same way here.
  * Both are called plugins in this context.
  *
- * To run this file, ensure that:
+ * Before running this file, ensure that:
  *
- * 1. You use yarn
- * 2. You run "yarn install && yarn build" on ./ and ./repositories
- * 3. That you after 2. run "yarn install" on ./ci
- * 4. Only after this you can run this file
+ * 1. You are using yarn
+ * 2. You have run "yarn install && yarn build" on ./ and ./repositories
+ * 3. After the previous step you have run "yarn install" on ./ci
  *
  * If you need to regenerate the output quickly, without rerunning the tests, set the SKIP_TESTS env variable
  */

--- a/ci/generate-workflows.js
+++ b/ci/generate-workflows.js
@@ -58,10 +58,10 @@ jobs:
               run: echo "::set-output name=dir::$(yarn cache dir)"
             - uses: actions/cache@v2
               with:
-                path: $\{{ steps.yarn-cache-dir-path.outputs.dir }}
-                key: $\{{ runner.os }}-yarn-$\{{ hashFiles('**/yarn.lock') }}
-                restore-keys: |
-                  $\{{ runner.os }}-yarn-
+                  path: $\{{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: $\{{ runner.os }}-yarn-$\{{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      $\{{ runner.os }}-yarn-
             - name: Install & build eslint-remote-tester
               run: |
                   yarn install


### PR DESCRIPTION
See: https://github.com/actions/cache/blob/main/examples.md#node---yarn

This makes the test runs somewhat speedier + it also helps lessen overall traffic towards npm I think