### PR TITLE
fix: update eslint-plugin-testing-library to v5

### DIFF
--- a/ci/plugin-configs/eslint-plugin-testing-library.config.js
+++ b/ci/plugin-configs/eslint-plugin-testing-library.config.js
@@ -16,7 +16,7 @@ module.exports = {
             'testing-library/no-await-sync-events': 'error',
             'testing-library/no-await-sync-query': 'error',
             'testing-library/no-container': 'error',
-            'testing-library/no-debug': 'error',
+            'testing-library/no-debugging-utils': 'error',
             'testing-library/no-dom-import': ['error', 'react'],
             'testing-library/no-manual-cleanup': 'error',
             'testing-library/no-node-access': 'error',


### PR DESCRIPTION
Breaking changes:
- rename `no-debug` to `no-debugging-utils`