### PR TITLE
feat: support typescript configs using `ts-node`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ libraries-io.json
 .cache-eslint-remote-tester
 eslint-remote-tester-results
 dist
-integration.config-*.js
+integration.config-*.[jt]s
 
 # Repository query script
 .query-cache

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -5,8 +5,8 @@ import { workerData, isMainThread } from 'worker_threads';
 
 import { getConfigWithDefaults } from './validator';
 import { CONFIGURATION_FILE_TEMPLATE } from './config-templates';
+import { loadConfig } from './load';
 import { WorkerData } from '@engine/types';
-import { Service } from 'ts-node';
 
 const DEFAULT_CONFIGURATION_FILE = 'eslint-remote-tester.config.js';
 const CLI_ARGS_CONFIG = ['-c', '--config'];
@@ -56,42 +56,6 @@ if (!fs.existsSync(CONFIGURATION_FILE)) {
     }
     process.exit();
 }
-
-let registerer: Service | null = null;
-
-/* istanbul ignore next */
-const interopRequireDefault = (obj: any): { default: any } =>
-    obj && obj.__esModule ? obj : { default: obj };
-
-const loadTSConfig = (configPath: string) => {
-    try {
-        registerer ||= require('ts-node').register() as Service;
-    } catch (e: any) {
-        if (e.code === 'MODULE_NOT_FOUND') {
-            throw new Error(
-                `'ts-node' is required for TypeScript configuration files. Make sure it is installed\nError: ${e.message}`
-            );
-        }
-
-        throw e;
-    }
-
-    registerer.enabled(true);
-
-    const configObject = interopRequireDefault(require(configPath)).default;
-
-    registerer.enabled(false);
-
-    return configObject;
-};
-
-const loadConfig = (configPath: string) => {
-    if (configPath.endsWith('.ts')) {
-        return loadTSConfig(configPath);
-    }
-
-    return require(configPath);
-};
 
 const configFileContents = loadConfig(path.resolve(CONFIGURATION_FILE));
 const config = getConfigWithDefaults(configFileContents);

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -6,6 +6,7 @@ import { workerData, isMainThread } from 'worker_threads';
 import { getConfigWithDefaults } from './validator';
 import { CONFIGURATION_FILE_TEMPLATE } from './config-templates';
 import { WorkerData } from '@engine/types';
+import { Service } from 'ts-node';
 
 const DEFAULT_CONFIGURATION_FILE = 'eslint-remote-tester.config.js';
 const CLI_ARGS_CONFIG = ['-c', '--config'];
@@ -56,7 +57,43 @@ if (!fs.existsSync(CONFIGURATION_FILE)) {
     process.exit();
 }
 
-const configFileContents = require(path.resolve(CONFIGURATION_FILE));
+let registerer: Service | null = null;
+
+/* istanbul ignore next */
+const interopRequireDefault = (obj: any): { default: any } =>
+    obj && obj.__esModule ? obj : { default: obj };
+
+const loadTSConfig = (configPath: string) => {
+    try {
+        registerer ||= require('ts-node').register() as Service;
+    } catch (e: any) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+            throw new Error(
+                `'ts-node' is required for TypeScript configuration files. Make sure it is installed\nError: ${e.message}`
+            );
+        }
+
+        throw e;
+    }
+
+    registerer.enabled(true);
+
+    const configObject = interopRequireDefault(require(configPath)).default;
+
+    registerer.enabled(false);
+
+    return configObject;
+};
+
+const loadConfig = (configPath: string) => {
+    if (configPath.endsWith('.ts')) {
+        return loadTSConfig(configPath);
+    }
+
+    return require(configPath);
+};
+
+const configFileContents = loadConfig(path.resolve(CONFIGURATION_FILE));
 const config = getConfigWithDefaults(configFileContents);
 
 export default config;

--- a/lib/config/load.ts
+++ b/lib/config/load.ts
@@ -1,0 +1,40 @@
+import type { Service } from 'ts-node';
+
+let registerer: Service | null = null;
+
+/* istanbul ignore next */
+const interopRequireDefault = (obj: any): { default: any } =>
+    obj && obj.__esModule ? obj : { default: obj };
+
+/** @internal */
+export const loadTSConfig = (configPath: string) => {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        registerer ||= require('ts-node').register() as Service;
+    } catch (e: any) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+            throw new Error(
+                `'ts-node' is required for TypeScript configuration files. Make sure it is installed\nError: ${e.message}`
+            );
+        }
+
+        throw e;
+    }
+
+    registerer.enabled(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const configObject = interopRequireDefault(require(configPath)).default;
+
+    registerer.enabled(false);
+
+    return configObject;
+};
+
+export const loadConfig = (configPath: string) => {
+    if (configPath.endsWith('.ts')) {
+        return loadTSConfig(configPath);
+    }
+
+    return require(configPath);
+};

--- a/package.json
+++ b/package.json
@@ -74,11 +74,18 @@
         "rimraf": "^3.0.2",
         "strip-ansi": "^6.0.0",
         "ts-jest": "^27.0.7",
+        "ts-node": "^10.4.0",
         "tsc-alias": "^1.3.9",
         "typescript": "^4.4.3"
     },
     "peerDependencies": {
-        "eslint": ">=7"
+        "eslint": ">=7",
+        "ts-node": ">=9.0.0"
+    },
+    "peerDependenciesMeta": {
+        "ts-node": {
+            "optional": true
+        }
     },
     "keywords": [
         "eslint",

--- a/test/integration/jest.config.integration.js
+++ b/test/integration/jest.config.integration.js
@@ -7,6 +7,6 @@ module.exports = {
         '<rootDir>/test/integration/jest.setup.integration.ts',
     ],
     watchPathIgnorePatterns: [
-        '<rootDir>/test/integration/integration.config-[0-9]*.js',
+        '<rootDir>/test/integration/integration.config-[0-9]*.[jt]s',
     ],
 };

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,4 +1,5 @@
 import { getConsoleLogCalls } from '../utils';
+import { loadTSConfig } from '@config/load';
 import validateConfig from '@config/validator';
 import {
     Config,
@@ -749,5 +750,24 @@ describe('validateConfig', () => {
                 'onComplete (fetch(api).then(parseResponse)) should be a function'
             );
         });
+    });
+});
+
+describe('loadTSConfig', () => {
+    test('a helpful error is thrown when ts-node is not present', () => {
+        jest.mock('ts-node', () => {
+            throw new (class extends Error {
+                public code;
+
+                constructor(message?: string) {
+                    super(message);
+                    this.code = 'MODULE_NOT_FOUND';
+                }
+            })();
+        });
+
+        expect(() => loadTSConfig('my-config')).toThrow(
+            `'ts-node' is required for TypeScript configuration files.`
+        );
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,6 +609,18 @@
   dependencies:
     chalk "^4.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@eslint/eslintrc@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.3.tgz#41f08c597025605f672251dcc4e8be66b5ed7366"
@@ -891,10 +903,25 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsconfig/node12@^1.0.9":
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7", "@tsconfig/node12@^1.0.9":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
   integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/babel__code-frame@^7.0.2":
   version "7.0.3"
@@ -1174,6 +1201,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -1183,6 +1215,11 @@ acorn@^8.2.4, acorn@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+acorn@^8.4.1:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1265,6 +1302,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1890,6 +1932,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2013,6 +2060,11 @@ diff-sequences@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4061,7 +4113,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -5496,6 +5548,24 @@ ts-jest@^27.0.7:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tsc-alias@^1.3.9:
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.3.9.tgz#0c9d1dd571c0a97af8159d20e7cd4ce6aaab1799"
@@ -5865,6 +5935,11 @@ yargs@^17.0.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yoga-layout-prebuilt@^1.9.6:
   version "1.10.0"


### PR DESCRIPTION
This should be all that's required to support typescript configs. This handles supporting explicit configs - I'll do a follow-up PR to allow the default config to be picked up if in TS.

@AriPerkkio could you give me some pointers on how you'd like to test this?

Closes #318 