### PR TITLE
feat: load typescript config by default if present

### DIFF
--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -8,8 +8,18 @@ import { CONFIGURATION_FILE_TEMPLATE } from './config-templates';
 import { loadConfig } from './load';
 import { WorkerData } from '@engine/types';
 
-const DEFAULT_CONFIGURATION_FILE = 'eslint-remote-tester.config.js';
+const DEFAULT_CONFIGURATION_FILE_NAME = 'eslint-remote-tester.config';
+const DEFAULT_CONFIGURATION_FILE_JS = `${DEFAULT_CONFIGURATION_FILE_NAME}.js`;
+const DEFAULT_CONFIGURATION_FILE_TS = `${DEFAULT_CONFIGURATION_FILE_NAME}.ts`;
 const CLI_ARGS_CONFIG = ['-c', '--config'];
+
+function determineDefaultConfigFile() {
+    if (fs.existsSync(DEFAULT_CONFIGURATION_FILE_TS)) {
+        return DEFAULT_CONFIGURATION_FILE_TS;
+    }
+
+    return DEFAULT_CONFIGURATION_FILE_JS;
+}
 
 export function resolveConfigurationLocation(): string {
     // Main thread can read config location from args
@@ -28,7 +38,7 @@ export function resolveConfigurationLocation(): string {
     return (
         cliConfigLocation ||
         workerDataConfiguration ||
-        DEFAULT_CONFIGURATION_FILE
+        determineDefaultConfigFile()
     );
 }
 
@@ -37,7 +47,7 @@ const CONFIGURATION_FILE = resolveConfigurationLocation();
 if (!fs.existsSync(CONFIGURATION_FILE)) {
     let defaultCreated = false;
 
-    if (CONFIGURATION_FILE === DEFAULT_CONFIGURATION_FILE) {
+    if (CONFIGURATION_FILE === DEFAULT_CONFIGURATION_FILE_JS) {
         fs.writeFileSync(
             CONFIGURATION_FILE,
             CONFIGURATION_FILE_TEMPLATE,
@@ -50,7 +60,7 @@ if (!fs.existsSync(CONFIGURATION_FILE)) {
     if (defaultCreated) {
         console.log(
             chalk.green(
-                `Default configuration file created: ${DEFAULT_CONFIGURATION_FILE}`
+                `Default configuration file created: ${DEFAULT_CONFIGURATION_FILE_JS}`
             )
         );
     }

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -771,3 +771,51 @@ describe('loadTSConfig', () => {
         );
     });
 });
+
+describe('resolveConfigurationLocation', () => {
+    let resolveConfigurationLocation: () => string;
+    const mockExistsSync = jest.fn().mockReturnValue(false);
+    const mockWriteFileSync = jest.fn();
+
+    beforeAll(() => {
+        jest.mock('fs', () => ({
+            existsSync: mockExistsSync,
+            writeFileSync: mockWriteFileSync,
+        }));
+
+        resolveConfigurationLocation =
+            require('../../lib/config').resolveConfigurationLocation;
+    });
+
+    beforeEach(() => {
+        mockExistsSync.mockClear();
+        mockWriteFileSync.mockClear();
+    });
+
+    test('should use value from --config', () => {
+        process.argv.push('--config', 'some-config.js');
+        const location = resolveConfigurationLocation();
+        process.argv.pop();
+        process.argv.pop();
+
+        expect(location).toBe('some-config.js');
+    });
+
+    test('should return default TypeScript config over JavaScript config', () => {
+        mockExistsSync.mockReturnValue(true);
+
+        expect(resolveConfigurationLocation()).toBe(
+            'eslint-remote-tester.config.ts'
+        );
+    });
+
+    test('should return default JavaScript config when TypeScript config does not exist', () => {
+        mockExistsSync.mockImplementation(
+            filename => filename !== 'eslint-remote-tester.config.ts'
+        );
+
+        expect(resolveConfigurationLocation()).toBe(
+            'eslint-remote-tester.config.js'
+        );
+    });
+});


### PR DESCRIPTION
Follow up from #320, for #318.

An existence check isn't the most ideal but the race condition is very unlikely to actually be an issue on a healthy system and the alternative would require a heavy refactor of how config loading is handled 😅 

@AriPerkkio got any pointers on what tests you'd like to see? I couldn't find any tests that handle the default config behaviour that I could add to.