### PR TITLE
docs: add symlinking example to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The underlying git integration is done via [simple-git](https://github.com/steve
 
 ## Configuration
 
-### Linking your eslint plugin as a dependency
+### Linking your local eslint plugin as a dependency
 
 In order for `eslint-remote-tester`'s `eslint` to know where the definitions for the new rules or modified existing rules are, your eslint plugin folder needs to be symlinked.
 In your plugin folder, dependending on which package manager you use, run:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ The underlying git integration is done via [simple-git](https://github.com/steve
 
 ## Configuration
 
+### Linking your eslint plugin as a dependency
+
+In order for `eslint-remote-tester`'s `eslint` to know where the definitions for the new rules or modified existing rules are, your eslint plugin folder needs to be symlinked.
+In your plugin folder, dependending on which package manager you use, run:
+
+```sh
+# Using npm package manager
+npm link
+npm link [your-plugin-name]
+
+# Or using yarn package manager
+yarn link
+yarn link [your-plugin-name]
+```
+
 ### package.json
 
 Add new script to your `package.json` file.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The underlying git integration is done via [simple-git](https://github.com/steve
 
 ### Linking your local eslint plugin as a dependency
 
-In order for `eslint-remote-tester`'s `eslint` to know where the definitions for the new rules or modified existing rules are, your eslint plugin folder needs to be symlinked.
+In order for `eslint-remote-tester`'s `eslint` to know where the definitions for the new rules or modified existing rules are, your local eslint plugin folder needs to be symlinked.
 In your plugin folder, dependending on which package manager you use, run:
 
 ```sh


### PR DESCRIPTION
Adds an example how to symlink the eslint plugin under development, so that `eslint-remote-tester` can be run locally.

Mentioned in #382 that the instructions are missing from `README`.