### PR TITLE
fix: parse `ruleId` from loading error message

### DIFF
--- a/lib/engine/worker-task.ts
+++ b/lib/engine/worker-task.ts
@@ -32,6 +32,7 @@ export type WorkerMessage =
 
 // Regex used to attempt parsing out rule which caused linter to crash
 const RULE_FROM_TRACE_REGEXP = /Rule: "(.*?)"/;
+const RULE_FROM_LOADING_ERROR = /Error while loading rule '(.*?)'/;
 const RULE_FROM_PATH_REGEXP = /rules\/(.*?)\.js/;
 const UNKNOWN_RULE_ID = 'unable-to-parse-rule-id';
 
@@ -153,6 +154,8 @@ function parseErrorStack(error: Error, file: SourceFile): LintMessage {
         stack.match(RULE_FROM_TRACE_REGEXP) ||
         // Older ESLint versions
         stack.match(RULE_FROM_PATH_REGEXP) ||
+        // Rule loading error
+        stack.match(RULE_FROM_LOADING_ERROR) ||
         [];
 
     const ruleId = ruleMatch.pop() || UNKNOWN_RULE_ID;


### PR DESCRIPTION
Parse `ruleId` from error message when error happens during rule loading https://github.com/eslint/eslint/blob/1866da5e1d931787256ecb825a803cac5835b71c/lib/linter/linter.js#L912

- Ref. https://github.com/jsx-eslint/eslint-plugin-react/issues/3637
- Ref. https://github.com/jsx-eslint/eslint-plugin-react/issues/3632