### PR TITLE
fix: fix config load on Windows

### DIFF
--- a/packages/eslint-remote-tester/src/config/load.ts
+++ b/packages/eslint-remote-tester/src/config/load.ts
@@ -1,3 +1,5 @@
+import {pathToFileURL} from 'node:url';
+
 /** @internal */
 export const loadTSConfig = async (configPath: string) => {
     let importx: typeof import('importx') | undefined = undefined;
@@ -37,6 +39,6 @@ export const loadConfig = async (configPath: string) => {
         return loadTSConfig(configPath);
     }
 
-    const { default: config } = await import(configPath);
+    const { default: config } = await import(pathToFileURL(configPath).href);
     return config;
 };

--- a/packages/eslint-remote-tester/src/config/load.ts
+++ b/packages/eslint-remote-tester/src/config/load.ts
@@ -1,4 +1,4 @@
-import {pathToFileURL} from 'node:url';
+import { pathToFileURL } from 'node:url';
 
 /** @internal */
 export const loadTSConfig = async (configPath: string) => {


### PR DESCRIPTION
On Windows, `import('E:\\\\path\\to\\config')` throws

```
Uncaught:
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'e:'
```