### PR TITLE
fix: add default exports entries

### DIFF
--- a/packages/eslint-remote-tester/package.json
+++ b/packages/eslint-remote-tester/package.json
@@ -10,11 +10,13 @@
     "exports": {
         ".": {
             "types": "./dist/types.d.ts",
-            "import": "./dist/index.js"
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
         },
         "./github-actions": {
             "types": "./dist/exports-for-compare-action.d.ts",
             "import": "./dist/exports-for-compare-action.js"
+            "default": "./dist/exports-for-compare-action.js"
         }
     },
     "files": [

--- a/packages/eslint-remote-tester/package.json
+++ b/packages/eslint-remote-tester/package.json
@@ -15,7 +15,7 @@
         },
         "./github-actions": {
             "types": "./dist/exports-for-compare-action.d.ts",
-            "import": "./dist/exports-for-compare-action.js"
+            "import": "./dist/exports-for-compare-action.js",
             "default": "./dist/exports-for-compare-action.js"
         }
     },

--- a/packages/repositories/package.json
+++ b/packages/repositories/package.json
@@ -11,11 +11,13 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
         },
         "./pathIgnorePatterns": {
             "types": "./dist/pathIgnorePatterns.d.ts",
-            "import": "./dist/pathIgnorePatterns.js"
+            "import": "./dist/pathIgnorePatterns.js",
+            "default": "./dist/pathIgnorePatterns.js"
         }
     },
     "files": [


### PR DESCRIPTION
This allows using the packages outside of a pure ESM context e.g. with [`require(esm)`](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require)