### PR TITLE
fix(config): unable to load TS configs with `jiti@^2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,11 @@ jobs:
               run: pnpm test
 
     integration-test:
+        name: Integration Tests (node ${{ matrix.node-version }}, jiti ${{ matrix.jiti-version }})
         runs-on: ubuntu-latest
         strategy:
             matrix:
+                jiti-version: [1, 2]
                 node-version: [18, 20]
         steps:
             - uses: actions/checkout@v4
@@ -59,6 +61,7 @@ jobs:
               run: |
                   pnpm install
                   pnpm build
+                  pnpm --filter eslint-remote-tester install -D jiti@${{ matrix.jiti-version }}
 
             - name: Run integration tests
               run: pnpm test:integration

--- a/packages/eslint-remote-tester/package.json
+++ b/packages/eslint-remote-tester/package.json
@@ -67,7 +67,7 @@
         "eslint-remote-tester-repositories": "workspace:*",
         "importx": "^0.5.2",
         "ink-testing-library": "^2.1.0",
-        "jiti": "^1.21.7",
+        "jiti": "^2.4.2",
         "node-pty": "^1.0.0",
         "strip-ansi": "^6.0.1",
         "typescript": "^5.8.3",

--- a/packages/eslint-remote-tester/src/config/load.ts
+++ b/packages/eslint-remote-tester/src/config/load.ts
@@ -31,8 +31,8 @@ export const loadTSConfig = async (configPath: string) => {
         // This is a good indicator that we're using v2+
         if (jitiModule.createJiti) {
             const jiti = jitiModule.createJiti(import.meta.url);
-            const config: any = await jiti.import(configPath);
-            return config.default;
+            const config = await jiti.import(configPath, {default: true});
+            return config;
         } else {
             // We're using jiti v1 here.
             return jitiModule.default(import.meta.url, {

--- a/packages/eslint-remote-tester/src/config/load.ts
+++ b/packages/eslint-remote-tester/src/config/load.ts
@@ -31,7 +31,7 @@ export const loadTSConfig = async (configPath: string) => {
         // This is a good indicator that we're using v2+
         if (jitiModule.createJiti) {
             const jiti = jitiModule.createJiti(import.meta.url);
-            const config = await jiti.import(configPath, {default: true});
+            const config = await jiti.import(configPath, { default: true });
             return config;
         } else {
             // We're using jiti v1 here.

--- a/packages/eslint-remote-tester/src/index.ts
+++ b/packages/eslint-remote-tester/src/index.ts
@@ -13,6 +13,8 @@ import logger from './progress-logger/index.js';
  * Results are written to ./eslint-remote-tester-results directory.
  */
 async function main() {
+    await validateConfig(config);
+
     const pool = config.repositories.map(repo => () => scanRepo(repo));
 
     async function execute(): Promise<void> {
@@ -23,8 +25,6 @@ async function main() {
             return execute();
         }
     }
-
-    await validateConfig(config);
     fileClient.prepareResultsDirectory();
 
     renderApplication();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.0.0
       eslint:
         specifier: 9.31.0
-        version: 9.31.0(jiti@1.21.7)
+        version: 9.31.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.31.0)
@@ -83,7 +83,7 @@ importers:
         version: 5.0.0
       eslint:
         specifier: 9.31.0
-        version: 9.31.0(jiti@1.21.7)
+        version: 9.31.0(jiti@2.4.2)
       eslint-plugin-local-rules:
         specifier: ^3.0.2
         version: 3.0.2
@@ -97,8 +97,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@types/react@17.0.87)
       jiti:
-        specifier: ^1.21.7
-        version: 1.21.7
+        specifier: ^2.4.2
+        version: 2.4.2
       node-pty:
         specifier: ^1.0.0
         version: 1.0.0
@@ -587,7 +587,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -951,7 +951,7 @@ packages:
       '@typescript-eslint/type-utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.38.0
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.4
       natural-compare: 1.4.0
@@ -973,7 +973,7 @@ packages:
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1021,7 +1021,7 @@ packages:
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1065,7 +1065,7 @@ packages:
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1653,7 +1653,7 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
     dev: true
 
   /eslint-plugin-local-rules@3.0.2:
@@ -1674,7 +1674,7 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       eslint-config-prettier: 10.1.8(eslint@9.31.0)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
@@ -1699,7 +1699,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /eslint@9.31.0(jiti@1.21.7):
+  /eslint@9.31.0(jiti@2.4.2):
     resolution: {integrity: sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
@@ -1739,7 +1739,7 @@ packages:
       ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      jiti: 1.21.7
+      jiti: 2.4.2
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
@@ -2137,11 +2137,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
-
-  /jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
     dev: true
 
   /jiti@2.4.2:
@@ -2883,7 +2878,7 @@ packages:
       '@typescript-eslint/parser': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.7)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
This change updates the load logic for TS Configs, to use jiti 2, if we've detected the new api, and falling back to the old api, otherwise.

I also updated the version of jiti to v2.  And added a new matrix for integration tests to run tests against both v1 and v2 or jiti. 

Lastly, I moved the config validation to be the first thing that happens in the cli, to catch cases where `repositories` wasn't defined in the config.  When config load was failing, the error was super ambiguous because it called `map` on `config.repositories` before running validation.  So, it took some digging to figure out what was wrong.

Closes #601 